### PR TITLE
fix setup not finding cudnn path, unable to start with empty transformations in config

### DIFF
--- a/remote_faster_whisper.py
+++ b/remote_faster_whisper.py
@@ -213,7 +213,7 @@ def start_api():
     api = FasterWhisperApi(
         **config["daemon"],
         faster_whisper_config=config["faster_whisper"],
-        transformations=config["transformations"],
+        transformations=config.get("transformations", {}),
     )
     api.start()
 

--- a/setup.sh
+++ b/setup.sh
@@ -44,7 +44,7 @@ ${dest_path}/bin/pip install --requirement requirements.txt
 cp remote_faster_whisper.py ${dest_path}/bin/remote_faster_whisper
 cp config.yaml ${dest_path}/config.yaml
 
-lib_path="$( dirname $( find ${dest_path}/lib -type f -name "libcudnn_ops_infer.so*" | head -1 ) )"
+lib_path="$( dirname $( find ${dest_path}/lib -type f -name "libcudnn_ops*" | head -1 ) )"
 
 if [[ ${service} == "true" ]]; then
     cat <<EOF >/etc/systemd/system/remote-faster-whisper.service


### PR DESCRIPTION
Hey,
Minor fixes so others don't have to spend time debugging.

1. changed the setup script so it has an easier time finding the cudnn path with newer cudnn versions
2. changed .py so the API can start even if the transformations key in the config is empty.

Thanks!